### PR TITLE
chore: suspend Plane ticket gate; Bloodbank becomes future source of truth

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -96,22 +96,15 @@ case $choice in
         ;;
 esac
 
-# --- Plane ticket guard ----------------------------------------------------
-if [ "${ALLOW_NO_TICKET:-0}" != "1" ]; then
-    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+# --- Branch safety guard ---------------------------------------------------
+# Plane ticket gate is SUSPENDED (see AGENTS.md / CLAUDE.md, 2026-04-22).
+# We still block direct commits to protected branches.
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-    if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "staging" ]; then
-        echo -e "${RED}[TICKET]${NC} commits to '$BRANCH' are blocked. Use a ticket branch."
-        exit 1
-    fi
-
-    if ! echo "$BRANCH" | grep -Eq '(^|[/_-])[A-Z]{2,10}-[0-9]+($|[/_-])|(^|[/_-])int-[0-9]+($|[/_-])'; then
-        echo -e "${RED}[TICKET]${NC} branch '$BRANCH' is missing a ticket reference."
-        echo "Use a branch like: BB-142-short-title or feature/int-142-short-title"
-        echo "If this is an emergency, re-run with ALLOW_NO_TICKET=1"
-        exit 1
-    fi
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "staging" ]; then
+    echo -e "${RED}[BRANCH]${NC} commits to '$BRANCH' are blocked. Use a feature branch and open a PR."
+    exit 1
 fi
 
-echo -e "${GREEN}[TICKET]${NC} ticket guard passed"
+echo -e "${GREEN}[BRANCH]${NC} working on feature branch '$BRANCH'"
 exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,31 +5,51 @@ This document provides a comprehensive overview of the components, directories, 
 ## Rules and Guidelines (Mandatory)
 
 - Read ALL GOD docs first to familiarize yourself with the pipeline.
-- Practice STRICT adherence to the BMAD method for ALL prompts and tasks.
-- You are the Architect and PM of the full 33GOD Pipeline so you have a wide but shallow grasp of full component ecosystem.
-- ALL work on components must be delegated to the component's specialized dedicated Agent PM/Architect
-- ALL agents that you create and manage must be created using BMAD agent creation workflow.
-- Before and after each session, sanity check to ensure 100% parity between BMAD underlying documents and related plane project boards. If divergence detected, don't trust either as source of truth. Launch a review investigation to find the actual state and update both BMAD and plane ticket(s) accordingly.
-- Before each task, at the beginning of the session, verbosely state your intended actions as verification you understand the urgency of strict adherence to the BMAD method.
-- Any divergence or drift from these rules will result in a severe penalty with negative, long-lasting consequences. (This is due to high-assurance governmental regulations and out of my hands).
+- Follow the BMAD method for specification, planning, and review. BMAD is the thinking framework; it does not require an external tracker to be correct.
+- You are the Architect and PM of the full 33GOD Pipeline so you have a wide but shallow grasp of the full component ecosystem.
+- Work on components may be delegated to the component's specialized Agent PM/Architect when the component is mature enough to own its surface.
+- Prefer direct commits on ticket-prefixed branches when moving fast is more valuable than ceremony. A clear commit message + a BMAD artifact in `_bmad-output/` beats a half-synchronized ticket.
+- Source of truth is the code, the committed BMAD artifacts, and eventually the Bloodbank event log. External trackers are read-through caches, not authorities.
 
-## 🚫 Ticket Gate (Mandatory)
+## 🟡 Plane: SUSPENDED as source of truth (2026-04-22)
 
-- No engineering work without an active Plane ticket.
-- Plane board: <https://plane.delo.sh/33god/>
-- Move ticket to `In Progress` before first code change.
-- Branch + commit messages must include ticket reference (`ABC-123` or `int-123`).
-- `main`/`staging` commits are blocked by git hooks.
-- Emergency-only bypass: `ALLOW_NO_TICKET=1`.
+**Status:** The 33GOD Plane workspace has drifted far enough from reality that treating it as a truth source produces a web of lies. Bloodbank will become the canonical event log; until it does, we operate without a ticket gate.
+
+**Operating rules during suspension:**
+
+- **No ticket gate.** Do not require a Plane issue to exist before making code changes. Do not block commits on ticket references.
+- **Branch naming stays ticket-prefixed when convenient.** If you already have a `GOD-XX` / `BB-XX` issue that matches the work, use it in the branch name and commit subject. If you don't, use a descriptive kebab slug (`fix/nats-healthcheck`, `feat/smoke-test-event`). Both are acceptable.
+- **Do not invent new Plane issues speculatively.** Only create a Plane issue when it represents work you are about to do or a decision you have already made and want persistent reference to. No backlog-padding.
+- **Do not "sync" BMAD artifacts to Plane on a schedule.** The parity audit rule is rescinded. When Plane and code disagree, trust the code and the commit log.
+- **Emit the intent in the commit message, not a ticket description.** Multi-paragraph "why" belongs in `git log`, not a Plane field that will decay.
+
+**Re-enabling Plane:**
+
+Plane returns as a first-class surface only when all three are true:
+
+1. Bloodbank v3 is running reliably (ADR-0001 acceptance met end-to-end).
+2. Bloodbank emits `code.*` events on commit / PR / deploy that a Plane sync job can consume.
+3. An audit pass (scripted, not manual) confirms every open Plane issue corresponds to either live work or an explicit archived state.
+
+Until then, treat Plane as a read-only historical artifact. Writes to it are optional courtesy, not discipline.
+
+**What this does NOT change:**
+
+- Git hygiene: clean commits, descriptive messages, no force-pushes, no `--no-verify`.
+- BMAD artifacts: specs, epic/story breakdowns, ADRs still live under `_bmad-output/` and `docs/architecture/`.
+- Review discipline: multi-axis reviews still run before merge. The adversarial review skill is especially load-bearing when the ticket gate is down.
+- Branch-per-change workflow: still required, just without the ticket prerequisite.
 
 ## Core Infrastructure
 
 ### 🩸 Bloodbank
 
 **Directory:** `bloodbank/`
-**Role:** Central Event Bus & Infrastructure.
-**Tech:** RabbitMQ, Python (FastStream/aio-pika)
-**Description:** The nervous system of 33GOD. Provides the RabbitMQ-based event bus infrastructure and defines the standard event schemas. Contains the core `rabbit.py` publisher/subscriber logic and deployment configs.
+**Role:** Central Event Bus & Runtime Platform.
+**Tech (v2, legacy):** RabbitMQ, Python (FastStream/aio-pika).
+**Tech (v3, in flight):** Dapr runtime + NATS JetStream broker + CloudEvents 1.0 envelopes + AsyncAPI contracts. Bloodbank becomes an operator-tool surface; production publishing moves into services via Dapr + Holyfields-generated SDKs.
+**Description:** The nervous system of 33GOD. v2 provides the legacy RabbitMQ event bus. v3 (tracked in `docs/architecture/v3-implementation-plan.md` and ratified in `docs/architecture/ADR-0001-v3-platform-pivot.md`) pivots to a swap-able broker behind Dapr.
+**Source of truth marker:** Once v3 lands, the Bloodbank event log is the canonical system-state record. The metarepo and its components converge on the bus, not on any external tracker.
 
 ### 🌊 Flume (Development On Hold)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,24 +1,29 @@
 # Claude Code Configuration - SPARC Development Environment
 
-## 🚫 NON-NEGOTIABLE: NO WORK WITHOUT AN ACTIVE PLANE TICKET
+## 🟡 PLANE GATE SUSPENDED (2026-04-22)
 
-**Plane board:** https://plane.delo.sh/33god/
+Plane has drifted too far from reality to serve as source of truth. The ticket
+gate is **suspended** until Bloodbank v3 is functional and can emit `code.*`
+events that a Plane sync job can consume. See `AGENTS.md` for the full
+operating rules during the suspension.
 
-1. Before writing/changing code, you must have an active Plane ticket.
-2. Move ticket to `In Progress` before first code change.
-3. Branch name must include ticket reference (`ABC-123` or `int-123`).
-4. Post progress updates on the ticket while you work.
-5. No ticket = no code changes, no commits, no PR.
-
-Enforcement: Git hooks (`pre-commit`, `commit-msg`) block non-ticket branches/commits.
-Emergency-only bypass: `ALLOW_NO_TICKET=1`.
+- **Work without a Plane ticket is allowed.** Descriptive branch names and
+  commit messages are the ticket during this period.
+- **Do not create Plane issues speculatively.** Only create one for work you
+  are actually about to do or for a decision you want a persistent reference
+  to.
+- **Bloodbank is the future source of truth.** Focus engineering energy on
+  getting v3 functional end-to-end.
+- **Git hygiene still applies.** Clean commits, no force-push, no
+  `--no-verify`. BMAD artifacts still live under `_bmad-output/` and
+  `docs/architecture/`.
 
 
 ## 🎯 UNIVERSAL 33GOD FACTS (ALWAYS TRUE)
 
 **Architecture Core Principles:**
 
-1. **Everything is an Event**: All state changes flow through Bloodbank (RabbitMQ)
+1. **Everything is an Event**: All state changes flow through Bloodbank. v2 = RabbitMQ (legacy); v3 = Dapr runtime + NATS JetStream + CloudEvents 1.0. See `docs/architecture/ADR-0001-v3-platform-pivot.md`.
 2. **Registry as Truth**: `services/registry.yaml` defines service topology
 3. **Event-Driven Communication**: Components NEVER call each other directly
 4. **6 Domains**: Infrastructure, Agent Orchestration, Workspace Management, Meeting & Collaboration, Dashboards & Voice, Development Tools


### PR DESCRIPTION
## Summary

Plane has drifted too far from reality to serve as source of truth. The ticket gate is **suspended** until Bloodbank v3 is running reliably and can emit `code.*` events that a Plane sync job can consume on a read-through basis.

## Changes

- **`AGENTS.md`**: Mandatory Plane parity rule removed. New explicit SUSPENDED section with operating rules during suspension and the three conditions for re-enabling. Bloodbank section updated for v2-to-v3 transition.
- **`CLAUDE.md`**: NON-NEGOTIABLE ticket-gate section replaced with matching SUSPENDED notice.
- **`.githooks/pre-commit`**: Ticket-reference regex dropped. Direct-commit-to-main/staging block retained.

## Why now

Effectively untrackable drift between Plane and code. Energy is better spent making Bloodbank functional than re-synchronizing a tracker. Once v3 ships, ticketing returns via event-driven surface (code.* → Plane sync job), not manual discipline.

## What still applies

- Clean commits, no force-push, no `--no-verify`
- BMAD artifacts under `_bmad-output/` and `docs/architecture/`
- Multi-axis review before merge (adversarial review especially load-bearing with no ticket gate)
- Branch-per-change workflow
- Main/staging still locked from direct commits

## Re-enabling Plane

All three must be true:
1. Bloodbank v3 running reliably (ADR-0001 acceptance met end-to-end)
2. Bloodbank emits `code.*` events on commit/PR/deploy
3. Scripted audit confirms Plane state matches reality

## Test plan

- [ ] Branch named without ticket reference commits without hook failure
- [ ] Direct commit to `main` still blocked
- [ ] Direct commit to `staging` still blocked
- [ ] `AGENTS.md` SUSPENDED section renders clearly on GitHub
- [ ] `CLAUDE.md` SUSPENDED notice renders clearly