### PR TITLE
docs(GOD-42): extract v3 platform plan + ADR to metarepo

### DIFF
--- a/_bmad-output/planning-artifacts/epic-god-42-v3-stories.md
+++ b/_bmad-output/planning-artifacts/epic-god-42-v3-stories.md
@@ -1,0 +1,252 @@
+---
+epic: GOD-42
+parent_epic: GOD-40
+title: 'Rebuild Blood Bank as NATS-based event backbone (v3 pivot)'
+status: 'ready-for-dev'
+created: '2026-04-19'
+related:
+  - docs/architecture/v3-implementation-plan.md
+  - docs/architecture/ADR-0001-v3-platform-pivot.md
+---
+
+# Epic GOD-42 — Blood Bank v3 Pivot: Story Breakdown
+
+Per the v3 implementation plan and ADR-0001. Stories map 1:1 to Plane
+implementation tickets (V3-001 through V3-011) to be created in the Bloodbank
+(BB) Plane project, plus one cross-component tracker in the Holyfields
+(HOLYF) project.
+
+All stories inherit the non-negotiable architecture decisions in ADR-0001.
+Each story's acceptance criteria must be checked as Given/When/Then before
+marking the ticket complete; reviewers cross-check against ADR-0001 and the
+implementation plan.
+
+## Story V3-001 — Sync Bloodbank submodule baseline
+
+**Goal:** Establish a clean, documented starting point on the `v3-refactor`
+branch of the bloodbank submodule.
+
+**Files touched:** None. This ticket records state only.
+
+**Given/When/Then:**
+- Given the bloodbank submodule on remote `v3-refactor`, when the ticket
+  owner inspects branch state, then branch is `v3-refactor` with preservation
+  tag `pre-preservation-2026-04-19` already present on the remote.
+- Given the cleanup delete set from the 2026-04-19 pruning pass, when the
+  ticket owner reviews the working tree, then no cleanup deletions have been
+  reverted.
+- Given the ticket, when linked documents are checked, then the description
+  links to `docs/architecture/v3-implementation-plan.md` and ADR-0001.
+
+## Story V3-002 — Create v3 Compose scaffold
+
+**Goal:** Stand up the `bloodbank/compose/v3/` Docker Compose skeleton for
+the v3 platform.
+
+**Files touched (inside bloodbank/):**
+- `compose/v3/docker-compose.yml`
+- `compose/v3/README.md`
+- `compose/v3/components/` (dir, for V3-003)
+- `compose/v3/nats/` (dir, for V3-004)
+- `compose/v3/apicurio/README.md`
+- `compose/v3/eventcatalog/README.md`
+
+**Given/When/Then:**
+- Given the scaffold in place, when `docker compose -f bloodbank/compose/v3/docker-compose.yml config` runs, then it parses without error and lists services `nats`, `dapr-placement`, `apicurio-registry`, `eventcatalog`.
+- Given the Compose file, when inspected, then no services reference v2
+  RabbitMQ containers or the `33god-rabbitmq` network.
+- Given the service naming, when checked against ADR-0001, then names and
+  labels use the `bloodbank-v3` compose project prefix.
+
+## Story V3-003 — Add Dapr component manifests
+
+**Goal:** Provide static Dapr component definitions for pubsub, statestore,
+and secretstore.
+
+**Files touched (inside bloodbank/):**
+- `compose/v3/components/pubsub.yaml`
+- `compose/v3/components/statestore.yaml`
+- `compose/v3/components/secretstore.yaml`
+
+**Given/When/Then:**
+- Given the pubsub manifest, when parsed, then it targets NATS JetStream and
+  is named `bloodbank-v3-pubsub`.
+- Given any manifest, when inspected, then no secret values are literal;
+  values either reference Dapr secret store or use placeholder env vars
+  prefixed `BLOODBANK_V3_`.
+- Given `compose/v3/README.md`, when read, then all three manifests are
+  documented with a one-paragraph purpose statement each.
+
+## Story V3-004 — Define NATS JetStream topology
+
+**Goal:** Lock the stream names, subject conventions, retention posture, and
+replay semantics before any publishing code lands.
+
+**Files touched (inside bloodbank/):**
+- `compose/v3/nats/streams.json`
+- `compose/v3/nats/README.md`
+
+**Given/When/Then:**
+- Given `streams.json`, when parsed, then it defines exactly
+  `BLOODBANK_V3_EVENTS` and `BLOODBANK_V3_COMMANDS` with subject patterns
+  `event.>`, `command.>`, and `reply.>`.
+- Given the README, when read, then it explains retention window,
+  dead-letter strategy, and replay preservation of original IDs.
+- Given the topology, when checked against ADR-0001, then it introduces no
+  coupling to RabbitMQ.
+
+## Story V3-005 — Add operator CLI v3 skeleton
+
+**Goal:** Produce a safe, side-effect-free CLI scaffold for v3 operator
+workflows.
+
+**Files touched (inside bloodbank/):**
+- `cli/v3/README.md`
+- `cli/v3/bb_v3.py`
+
+**Given/When/Then:**
+- Given the scaffold, when `python -m compileall cli/v3` runs, then it
+  exits 0.
+- Given `python cli/v3/bb_v3.py doctor`, when run against a complete
+  scaffold, then it reports success without performing any network I/O.
+- Given the CLI, when any subcommand is invoked (`doctor`, `trace`,
+  `replay`, `emit`), then no production traffic is published.
+
+## Story V3-006 — Add platform bootstrap check
+
+**Goal:** Provide a junior-friendly verification script that catches missing
+scaffold pieces without requiring Docker, Dapr, or network access.
+
+**Files touched (inside bloodbank/):**
+- `ops/v3/bootstrap/README.md`
+- `ops/v3/bootstrap/check-platform.sh`
+
+**Given/When/Then:**
+- Given a complete scaffold, when `bash ops/v3/bootstrap/check-platform.sh`
+  runs, then it exits 0 and prints a `PASS` line per checked artifact.
+- Given a missing file, when the script runs, then output names the missing
+  file and the exit code is non-zero.
+- Given the script, when inspected, then it performs no Docker, Dapr, NATS,
+  or network calls.
+
+## Story V3-007 — Add replay and trace docs
+
+**Goal:** Document operator expectations for replay and trace workflows
+before implementing real tooling.
+
+**Files touched (inside bloodbank/):**
+- `ops/v3/replay/README.md`
+- `ops/v3/trace/README.md`
+
+**Given/When/Then:**
+- Given the replay doc, when read, then it defines what data is safe to
+  replay and states that replays preserve original IDs while adding replay
+  metadata.
+- Given the trace doc, when read, then it defines the expected use of
+  `correlation_id`, `causation_id`, and `traceparent`.
+- Given either doc, when read, then it does not claim production replay or
+  trace tooling is implemented yet.
+
+## Story V3-008 — Add adapter migration scaffolds
+
+**Goal:** Prepare migration directories that bridge v2 consumers to v3
+without writing migration code yet.
+
+**Files touched (inside bloodbank/):**
+- `adapters/v3/README.md`
+- `adapters/v3/hookd/README.md`
+- `adapters/v3/openclaw/README.md`
+- `adapters/v3/infra_dispatcher/README.md`
+
+**Given/When/Then:**
+- Given each adapter README, when read, then it names the v2 component it
+  replaces and the v3 publish path via Holyfields-generated contracts +
+  Dapr + NATS.
+- Given any adapter directory, when inspected, then it contains no
+  executable migration code (docs and stubs only in this wave).
+- Given the top-level `adapters/v3/README.md`, when read, then it states
+  that adapters must not invent local envelopes.
+
+## Story V3-009 — Link implementation plan from architecture docs
+
+**Goal:** Make the plan discoverable from where readers already look.
+
+**Files touched (inside bloodbank/):**
+- `README.md`
+- `docs/architecture/README.md`
+- `docs/architecture/overhaul-backlog.md`
+
+**Given/When/Then:**
+- Given each linking file, when a reader follows the link, then it resolves
+  to `docs/architecture/v3-implementation-plan.md` in the metarepo (not the
+  legacy bloodbank copy).
+- Given `bloodbank/GOD.md`, when read, then it remains clearly marked as
+  legacy v2 / current-state context.
+- Given the architecture index, when read, then it also links to the
+  Holyfields contract work tracker (V3-010 output).
+
+## Story V3-010 — Create Holyfields contract work tracker
+
+**Goal:** Document the Holyfields-side work that must happen in a sibling
+repo, without editing Holyfields from Bloodbank.
+
+**Files touched (inside bloodbank/):**
+- `docs/architecture/v3-holyfields-contract-work.md`
+
+**Plane side effect:** one `HOLYF-*` ticket is created in the Holyfields
+Plane project, linked from this file.
+
+**Given/When/Then:**
+- Given the tracker doc, when read, then it lists: CloudEvents base schema,
+  command envelope schema, AsyncAPI template, SDK generation pipeline
+  (Python + TypeScript), EventCatalog source, Apicurio sync.
+- Given the tracker, when checked against the bloodbank repo, then no
+  Holyfields code is edited from this ticket.
+- Given the Plane tracker ticket, when checked, then it is linked from
+  this doc and from `GOD-42`.
+
+## Story V3-011 — Verify first scaffold wave
+
+**Goal:** Run the full static verification suite and record results before
+declaring sprint one done.
+
+**Files touched:** None (verification only; may append to a
+`docs/architecture/verification-log.md` inside bloodbank).
+
+**Verification commands:**
+```bash
+# inside bloodbank/
+git status --short
+python -m compileall cli/v3
+bash ops/v3/bootstrap/check-platform.sh
+docker compose -f compose/v3/docker-compose.yml config   # optional
+```
+
+**Given/When/Then:**
+- Given the scaffold wave is complete, when static checks run, then all
+  three required commands exit 0.
+- Given Docker Compose is not available or requires image pulls, when the
+  optional check is skipped, then the skip is documented with the reason.
+- Given both reviews (spec review + code quality review) are complete, when
+  statuses are checked in Plane, then both show passing before this ticket
+  closes.
+
+## Dependency order
+
+```
+V3-001 (baseline)
+  ├── V3-002 (compose scaffold)
+  │     ├── V3-003 (dapr manifests)
+  │     └── V3-004 (nats topology)
+  ├── V3-005 (cli skeleton)
+  ├── V3-006 (bootstrap check)
+  ├── V3-007 (replay + trace docs)
+  ├── V3-008 (adapter scaffolds)
+  ├── V3-009 (cross-references)
+  └── V3-010 (holyfields tracker)
+V3-011 (verify)   ← blocked by all of the above
+```
+
+Grouping permitted per the plan's subagent orchestration protocol:
+Group A = V3-002 + V3-003 + V3-004; Group B = V3-005 + V3-006;
+Group C = V3-007 + V3-008 + V3-009 + V3-010. V3-011 is ungrouped.

--- a/docs/architecture/ADR-0001-v3-platform-pivot.md
+++ b/docs/architecture/ADR-0001-v3-platform-pivot.md
@@ -1,0 +1,174 @@
+# ADR-0001: 33GOD Event Platform v3 — Dapr + NATS JetStream + CloudEvents
+
+**Status:** Accepted
+**Date:** 2026-04-19
+**Plane:** GOD-42
+**Supersedes:** implicit v2 assumptions (RabbitMQ + ad-hoc schema validation + Bloodbank as primary publisher).
+
+## Context
+
+The 33GOD event platform (v2) emerged organically around RabbitMQ, FastStream,
+and Bloodbank-as-everything. That worked for the early pipeline but created
+three structural pressures as scope widened:
+
+1. **Schema governance was implicit.** Bloodbank validated at publish time
+   against schemas it defined itself. Producing services had no first-class
+   contract story.
+2. **Bloodbank accumulated responsibility.** It became both the event bus and
+   the publisher, which coupled broker concerns to domain publishing concerns.
+3. **Tooling drifted.** RabbitMQ management, consumer scaffolding, replay,
+   trace, and observability were each solved ad-hoc per component, with no
+   shared runtime.
+
+The 2026-04-19 metarepo slimdown (GOD-41) cleared the surface area to focus
+the next build phase. This ADR ratifies the v3 direction that the planning
+work in `bloodbank/v3-implementation-plan.md` produced, and promotes it to
+metarepo scope because the decisions span Bloodbank, Holyfields, and shared
+platform services.
+
+## Decision
+
+We pivot to a v3 event platform with the following locked choices.
+
+### Runtime and transport
+
+- **Runtime platform:** Dapr. Dapr provides the pub/sub, state store, and
+  secret store abstractions. Services use Dapr APIs; swapping the broker
+  becomes a component-manifest change rather than a code change.
+- **Broker:** NATS JetStream. JetStream supplies durable streams, replay,
+  and subject hierarchies aligned with the `event.*` / `command.*` / `reply.*`
+  conventions below.
+- **Local and self-hosted deployment:** Docker Compose. `compose/v3/` is the
+  canonical sandbox; Kubernetes is explicitly out of scope for this phase.
+
+### Envelopes
+
+- **Immutable events:** CloudEvents 1.0, with 33GOD extension fields
+  (`correlationid`, `causationid`, `producer`, `service`, `domain`,
+  `schemaref`, `traceparent`).
+- **Commands:** separate command envelope with `command_id`, `target_service`,
+  `timeout_ms`, `reply_to`, and payload schema reference. Commands are
+  mutable by intent; events are not.
+- **Subjects:** `event.<domain>.<entity>.<action>`, `command.<target>.<verb>`,
+  `reply.<target>.<verb>`.
+
+### Contracts and discovery
+
+- **Description format:** AsyncAPI at the service level.
+- **Central contract and service registry:** Holyfields. Owns CloudEvents
+  base schema, command envelope schema, per-service AsyncAPI documents,
+  per-event and per-command schemas, and generated SDKs (Python, TypeScript).
+- **Human + agent discovery:** EventCatalog, generated from Holyfields.
+- **Runtime schema governance:** Apicurio Registry, synchronized from
+  Holyfields. Producers and consumers fetch schemas at runtime from Apicurio;
+  Holyfields is the write side.
+
+### Role reassignments
+
+- **Bloodbank:** runtime and operations only. Dapr manifests, NATS bootstrap,
+  Compose files, operator CLI (doctor / trace / replay / emit), adapter
+  migration points, replay and dead-letter tools, v3 operations docs.
+  Bloodbank does **not** own business event schemas.
+- **Bloodbank CLI (`bb_v3`):** operator tool. It is not the primary production
+  publish path; production traffic goes through Dapr publishers inside
+  services. The CLI is for emission tests, trace walkthroughs, and replay.
+- **Holyfields:** contracts and generation only.
+- **Services (producing and consuming):** own their business event/command
+  schemas. They publish via Dapr using Holyfields-generated SDKs. They do
+  not hand-roll envelopes.
+
+## Naming invariants
+
+Locked by this ADR; do not reopen inside implementation tickets.
+
+| Kind | Value |
+|---|---|
+| Compose project | `bloodbank-v3` |
+| Dapr pub/sub component | `bloodbank-v3-pubsub` |
+| Dapr app ID prefix | `bloodbank-v3-` |
+| NATS events stream | `BLOODBANK_V3_EVENTS` |
+| NATS commands stream | `BLOODBANK_V3_COMMANDS` |
+| NATS event subject prefix | `event.` |
+| NATS command subject prefix | `command.` |
+| NATS reply subject prefix | `reply.` |
+
+## Consequences
+
+### Positive
+
+- **Swap-ability.** Dapr decouples broker from code; a future move away from
+  NATS is a component manifest swap, not a rewrite.
+- **Contract clarity.** Holyfields owns the write side; Apicurio owns the
+  read side at runtime. Services cannot publish events whose schema is not
+  registered.
+- **Traceability.** CloudEvents + `correlationid` + `causationid` +
+  `traceparent` give a first-class distributed trace story without bolt-on
+  middleware.
+- **Observability surface.** EventCatalog provides human/agent discovery;
+  operators stop grep-ing source for event types.
+- **Operator separation.** Bloodbank becomes a focused operator tool;
+  service teams own their own publish path, which unblocks parallel work.
+
+### Negative / costs
+
+- **Learning surface.** Four moving parts (Dapr, NATS JetStream, AsyncAPI,
+  EventCatalog) vs v2's one (RabbitMQ). Mitigated by scaffolding first,
+  production traffic later, and by the documentation-heavy first scaffold
+  wave.
+- **Contract generation pipeline is new.** Holyfields must produce Python
+  and TypeScript SDKs that are consumable in services. This is tracked
+  separately under V3-010's Holyfields tracker and blocks production cutover.
+- **Migration path for v2 consumers.** Existing RabbitMQ consumers (infra
+  dispatcher, node-red flow orchestrator, etc.) must either migrate or run
+  in parallel. Adapter scaffolds (V3-008) exist specifically to plan this.
+- **Running Apicurio adds ops surface.** Another long-lived service to
+  operate. Accepted because alternative is re-implementing schema governance
+  in-house, which has a worse long-term cost.
+
+### Neutral / deferred
+
+- **Kubernetes.** Out of scope. Compose is the deployment surface until v3
+  stabilizes.
+- **Multi-region / clustering.** Out of scope. Single-node JetStream for now.
+- **Dapr state store backend.** Default (Redis) acceptable for scaffold;
+  production backend is a later decision.
+- **Replay semantics.** Documented in V3-007; actual tooling beyond docs is
+  deferred until after scaffold wave.
+
+## Alternatives considered
+
+- **Stay on RabbitMQ + FastStream, fix schema governance in place.** Rejected
+  because it preserves Bloodbank-as-everything and keeps schema validation
+  scattered. Revisit cost would be higher later.
+- **Kafka instead of NATS JetStream.** Rejected for single-operator /
+  self-hosted fit. JetStream covers our durability and replay needs at a
+  fraction of the operational complexity, without sacrificing the subject
+  hierarchy we want.
+- **Skip Dapr, publish to NATS directly from services.** Rejected because it
+  locks services to NATS specifically and loses the secret/state
+  abstractions. We want the broker to be swappable.
+- **Skip Apicurio, use only Holyfields at runtime.** Rejected because it
+  forces services to depend on Holyfields repo checkout or a custom API at
+  runtime. Apicurio is a boring, standard registry with known semantics.
+- **Skip EventCatalog.** Rejected because discovery becomes a grep problem
+  again. EventCatalog pays for itself within weeks once event count exceeds
+  ~15.
+
+## Implementation
+
+See `docs/architecture/v3-implementation-plan.md` for the ticket-level plan
+(V3-001 through V3-011) and Plane decomposition.
+
+## Review triggers
+
+Revisit this ADR if:
+
+- A service cannot produce a CloudEvents envelope because of language or
+  runtime constraints.
+- Dapr performance characteristics break an SLA we commit to.
+- NATS JetStream clustering requirements change the deployment model.
+- Apicurio operational cost exceeds its coordination benefit.
+- Holyfields SDK generation cannot keep up with contract change rate.
+
+In each case, the ADR is amended with a new status block; decisions are not
+silently revised.

--- a/docs/architecture/v3-implementation-plan.md
+++ b/docs/architecture/v3-implementation-plan.md
@@ -1,0 +1,356 @@
+# 33GOD Event Platform v3 — Implementation Plan
+
+**Status:** Source of truth (promoted from `bloodbank/v3-implementation-plan.md` on 2026-04-19 under GOD-42).
+**Scope:** Cross-component pivot covering Bloodbank (runtime/ops), Holyfields (contracts/generation), and metarepo-level platform wiring (Dapr runtime, NATS JetStream, EventCatalog, Apicurio Registry).
+**Companion:** [ADR-0001](./ADR-0001-v3-platform-pivot.md) — codified non-negotiable decisions.
+**Epic:** GOD-40 Blood Bank Event Backbone Rebuild → Story GOD-42.
+
+This document is the execution plan for the 33GOD v3 event platform pivot. It
+is meant to be followed by a mixed-seniority team without reinterpreting the
+architecture on every ticket.
+
+Use this plan as the source of truth for Plane ticket decomposition and
+component coordination. Component-local specialization (e.g. Holyfields
+contract generation specifics) lives in those component repos; cross-component
+contracts and runtime decisions live here.
+
+## Current baseline
+
+The starting point is the Bloodbank submodule on branch `v3-refactor`, created
+from commit `14d9122`, with preservation tag `pre-preservation-2026-04-19` on
+its remote. The parent 33GOD repository references the `v3-refactor` submodule
+commit after the 2026-04-19 slimdown (GOD-41).
+
+Cleanup deletions from the pruning pass were intentionally committed. Do not
+revert them without explicit user direction. New v3 work lands in clearly
+named `v3` paths so it does not depend on removed legacy files.
+
+## Source documents
+
+Read these before editing code or tickets:
+
+- `docs/architecture/ADR-0001-v3-platform-pivot.md` (decision ratification)
+- `bloodbank/docs/architecture/bloodbank-vnext.md`
+- `bloodbank/docs/architecture/dapr-vs-faststream.md`
+- `bloodbank/docs/architecture/overhaul-backlog.md`
+- `bloodbank/GOD.md` (legacy v2 context)
+- `bloodbank/README.md`
+- `AGENTS.md` (metarepo)
+- `services/registry.yaml` (surviving service topology)
+
+The vNext docs inside bloodbank define the target bloodbank-internal
+architecture. Metarepo-level architecture decisions are in ADR-0001 and this
+document.
+
+## Non-negotiable architecture decisions
+
+Ratified in ADR-0001. Do not reopen inside implementation tickets.
+
+- **Runtime platform:** Dapr.
+- **Broker:** NATS JetStream.
+- **Immutable event envelope:** CloudEvents 1.0.
+- **Command envelope:** separate from events (mutable, correlated).
+- **Contract description:** AsyncAPI.
+- **Human/agent discovery:** EventCatalog.
+- **Runtime schema governance:** Apicurio Registry.
+- **Local + self-hosted deployment:** Docker Compose.
+- **Bloodbank CLI role:** operator tool, not the primary production publish path.
+- **Holyfields role:** central contract and service registry.
+- **Business event schemas:** owned by their producing services and registered
+  via Holyfields. Bloodbank does not own business schemas.
+
+## Repository boundaries
+
+This plan separates Bloodbank and Holyfields by intent.
+
+**Bloodbank owns runtime and operations** (inside the `bloodbank/` submodule):
+
+- Dapr component manifests (pubsub, statestore, secretstore).
+- NATS JetStream bootstrap (streams, subjects, retention).
+- Compose files for the platform sandbox.
+- Operator CLI scaffolding (`bb_v3` doctor / trace / replay / emit).
+- Adapter migration points (hookd, openclaw, infra_dispatcher).
+- Replay, trace, and dead-letter tools.
+- Documentation that explains how to operate v3.
+
+**Holyfields owns contracts and generation** (inside the `holyfields/` submodule):
+
+- CloudEvents base schema.
+- Command envelope schema.
+- Service-level AsyncAPI documents.
+- Service-owned event and command schemas.
+- Generated Python and TypeScript SDKs.
+- EventCatalog source and generated catalog output.
+- Apicurio schema synchronization.
+
+**Metarepo owns cross-component coordination** (here):
+
+- This implementation plan.
+- ADR-0001 decision record.
+- Plane epic + story tracking (GOD-40, GOD-42).
+- Cross-repo integration checkpoints.
+- Smoke test definitions spanning multiple components.
+
+If a ticket requires editing `holyfields/` from a Bloodbank ticket, do that
+work in the Holyfields repo or a dedicated Holyfields ticket. Do not hide
+Holyfields changes inside Bloodbank.
+
+## Target Bloodbank v3 layout
+
+Paths are relative to `bloodbank/` inside the metarepo.
+
+```text
+bloodbank/
+  compose/
+    v3/
+      docker-compose.yml
+      README.md
+      components/
+        pubsub.yaml
+        statestore.yaml
+        secretstore.yaml
+      nats/
+        README.md
+        streams.json
+      apicurio/
+        README.md
+      eventcatalog/
+        README.md
+  ops/
+    v3/
+      bootstrap/
+        README.md
+        check-platform.sh
+      trace/
+        README.md
+      replay/
+        README.md
+  cli/
+    v3/
+      README.md
+      bb_v3.py
+  adapters/
+    v3/
+      README.md
+      hookd/
+        README.md
+      openclaw/
+        README.md
+      infra_dispatcher/
+        README.md
+  docs/
+    architecture/
+      bloodbank-vnext.md
+      dapr-vs-faststream.md
+      overhaul-backlog.md
+      v3-holyfields-contract-work.md
+```
+
+The first scaffold must be documentation-heavy and safe. Do not wire
+production traffic to Dapr or NATS in the first pass.
+
+## Naming rules
+
+- Plane parent story: `GOD-42` (in `33GOD Infrastructure` project).
+- Implementation ticket series: `BB-*` (in `Bloodbank` Plane project), tagged
+  `v3-refactor` label.
+- Holyfields tracker: one `HOLYF-*` ticket referenced by BB implementation tickets.
+- Branch name (in bloodbank): `v3-refactor`.
+- Compose project name: `bloodbank-v3`.
+- Dapr pub/sub component name: `bloodbank-v3-pubsub`.
+- Dapr app ID prefix: `bloodbank-v3-`.
+- NATS stream for immutable events: `BLOODBANK_V3_EVENTS`.
+- NATS stream for commands: `BLOODBANK_V3_COMMANDS`.
+- NATS subject prefix for events: `event.`
+- NATS subject prefix for commands: `command.`
+- NATS subject prefix for replies: `reply.`
+
+## Message contracts
+
+Bloodbank must not invent business schemas. The temporary local examples below
+exist only to prove platform plumbing until Holyfields-generated packages are
+available.
+
+**Immutable event envelope (CloudEvents 1.0 + 33GOD extensions):**
+
+```json
+{
+  "specversion": "1.0",
+  "id": "uuid",
+  "source": "urn:33god:service:example",
+  "type": "artifact.created",
+  "subject": "artifact/example-id",
+  "time": "2026-04-12T00:00:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "urn:33god:holyfields:schema:artifact.created.v1",
+  "correlationid": "uuid",
+  "causationid": "uuid-or-null",
+  "producer": "example-service",
+  "service": "artifact-service",
+  "domain": "artifact",
+  "schemaref": "artifact.created.v1",
+  "traceparent": "w3c-trace-context",
+  "data": {}
+}
+```
+
+**Command envelope:**
+
+```json
+{
+  "command_id": "uuid",
+  "command_type": "artifact.rebuild",
+  "target_service": "artifact-service",
+  "issued_by": "operator-or-service",
+  "issued_at": "2026-04-12T00:00:00Z",
+  "timeout_ms": 300000,
+  "correlation_id": "uuid",
+  "causation_id": "uuid-or-null",
+  "reply_to": "reply.artifact-service.rebuild",
+  "payload_schema": "artifact.rebuild.v1",
+  "payload": {}
+}
+```
+
+## Developer workflow
+
+For every implementation ticket:
+
+1. Read this plan and the ticket acceptance criteria.
+2. Confirm the current branch is `v3-refactor` (inside bloodbank) or the
+   appropriate component branch.
+3. Confirm the ticket path scope before editing.
+4. Make only the files required by the ticket.
+5. Run the ticket-specific verification command.
+6. Run a local self-review.
+7. Ask for spec review.
+8. Ask for code quality review.
+9. Mark the ticket complete only after both reviews pass.
+
+Do not mark a ticket complete if verification was skipped.
+
+## Verification commands
+
+First scaffold wave:
+
+```bash
+# Inside bloodbank submodule
+git status --short
+python -m compileall cli/v3
+bash ops/v3/bootstrap/check-platform.sh
+```
+
+`check-platform.sh` must not require Docker to be running. It validates file
+presence and static configuration only.
+
+Once the Compose stack exists, this optional manual check:
+
+```bash
+docker compose -f bloodbank/compose/v3/docker-compose.yml config
+```
+
+Baseline verification must not require network access or pulling images.
+
+## Plane ticket set
+
+### Parent (metarepo)
+
+Story `GOD-42` — **Rebuild Blood Bank as NATS-based event backbone**
+(child of epic `GOD-40 Blood Bank Event Backbone Rebuild`).
+
+Description pointer: this file + ADR-0001.
+
+### Child implementation tickets (Bloodbank project)
+
+Each is a `BB-*` ticket linked to `GOD-42` via the description. Create these
+under the Bloodbank Plane project; apply label `v3-refactor`.
+
+| ID | Title | Scope |
+|---|---|---|
+| V3-001 | Sync Bloodbank submodule baseline | Confirm branch, record starting commit, preserve cleanup deletions |
+| V3-002 | Create v3 Compose scaffold | `compose/v3/` docker-compose.yml + component dirs |
+| V3-003 | Add Dapr component manifests | pubsub.yaml, statestore.yaml, secretstore.yaml |
+| V3-004 | Define NATS JetStream topology | streams.json + README defining subjects, retention, DLQ |
+| V3-005 | Add operator CLI v3 skeleton | `bb_v3` with doctor/trace/replay/emit stubs |
+| V3-006 | Add platform bootstrap check | `check-platform.sh` static validator |
+| V3-007 | Add replay and trace docs | operator workflow documentation |
+| V3-008 | Add adapter migration scaffolds | hookd, openclaw, infra_dispatcher README stubs |
+| V3-009 | Link implementation plan from architecture docs | cross-reference sweep |
+| V3-010 | Create Holyfields contract work tracker | tracker in Holyfields project + link from here |
+| V3-011 | Verify first scaffold wave | run all static checks + document results |
+
+Full acceptance criteria per ticket live in the Plane issues and in the
+per-story BMAD files at `_bmad-output/planning-artifacts/story-v3-*.md`.
+
+### Child tracker (Holyfields project)
+
+Create one `HOLYF-*` ticket linked from V3-010:
+
+- CloudEvents base schema registration
+- Command envelope schema registration
+- AsyncAPI document template
+- SDK generation pipeline (Python + TypeScript)
+- EventCatalog source
+- Apicurio synchronization script
+
+Mark as external to Bloodbank; block V3 production rollout until this work
+closes.
+
+## Subagent orchestration protocol
+
+Use subagent-driven development for the scaffold wave.
+
+**Controller rules:**
+
+- Dispatch a fresh implementer subagent per ticket.
+- Do not dispatch multiple implementer subagents in parallel.
+- Give each subagent the full ticket text from this plan + its Plane issue.
+- Give each subagent the exact allowed write paths.
+- Require each implementer to self-review before returning.
+- Dispatch a spec reviewer after implementation.
+- Dispatch a code quality reviewer only after spec review passes.
+- If a reviewer finds issues, send the issue list back to the implementer and
+  re-review.
+- Mark a Plane ticket complete only after both review stages pass.
+
+For the first session, scaffold tickets may be grouped only when their write
+sets are disjoint and the controller can still review them thoroughly:
+
+- **Group A:** V3-002, V3-003, V3-004 — platform files under `compose/v3/`
+- **Group B:** V3-005, V3-006 — operator CLI and bootstrap checks under
+  `cli/v3/` and `ops/v3/bootstrap/`
+- **Group C:** V3-007, V3-008, V3-009, V3-010 — docs and adapter scaffolds
+
+V3-011 is not grouped; it is a verification gate after the scaffold groups.
+
+## Stop conditions
+
+Stop and ask for direction if any of these happen:
+
+- A ticket requires editing `holyfields/` from the Bloodbank submodule.
+- A migration would route live production traffic to Dapr or NATS.
+- The cleanup delete set needs to be reverted.
+- Plane API creation fails after authentication and endpoint checks.
+- Docker Compose requires pulling images during a static verification step.
+- ADR-0001's non-negotiable decisions appear to require revisiting (escalate
+  before proceeding).
+
+## Sprint one definition of done
+
+- `GOD-42` story is linked to ADR-0001 and this plan.
+- All `BB-*` child tickets exist under the V3 set in the Bloodbank project.
+- `HOLYF-*` tracker ticket exists and is linked from V3-010.
+- The Bloodbank v3 scaffold exists under the target paths.
+- The operator CLI and bootstrap check compile or run locally.
+- The implementation plan is linked from the bloodbank architecture docs.
+- Spec review and code quality review have passed for the scaffold wave.
+
+## Extraction provenance
+
+This document was extracted from `bloodbank/v3-implementation-plan.md` to the
+metarepo on 2026-04-19 under Plane GOD-42 because the plan spans multiple
+components (Bloodbank, Holyfields, services/, metarepo-level platform
+wiring). The bloodbank copy remains in place for backward compatibility of
+deep links; this metarepo copy is the source of truth going forward. When
+the first V3 implementation ticket lands, a short stub in bloodbank will
+redirect deep links to this file.


### PR DESCRIPTION
## Summary

Promotes `bloodbank/v3-implementation-plan.md` to the metarepo as source of truth (the v3 pivot spans Bloodbank, Holyfields, and metarepo-level platform wiring). Adds ADR-0001 ratifying non-negotiable decisions and a BMAD-style story breakdown.

Replaces closed PR #10 (stacked on the now-merged GOD-41 branch); rebased onto current main.

## Files

- `docs/architecture/v3-implementation-plan.md` — metarepo-framed execution plan; naming invariants, repository boundaries, BB-*/HOLYF-* ticket decomposition
- `docs/architecture/ADR-0001-v3-platform-pivot.md` — ratified decisions: Dapr + NATS JetStream + CloudEvents 1.0 + separate command envelope + AsyncAPI + EventCatalog + Apicurio + Compose; Bloodbank as operator tool; Holyfields owns contracts
- `_bmad-output/planning-artifacts/epic-god-42-v3-stories.md` — BMAD story breakdown with Given/When/Then acceptance for V3-001..V3-011

## Plane wiring (already created)

| Ticket | Project | Purpose |
|---|---|---|
| GOD-42 | 33GOD Infrastructure | Parent story; description links plan + ADR |
| BB-17..BB-27 | Bloodbank | V3-001..V3-011 implementation tickets |
| HOLYF-2 | Holyfields | Contract-work cross-component tracker |

## Test plan

- [ ] Architecture docs render cleanly on GitHub
- [ ] Plane GOD-42 shows the three metarepo artifact references
- [ ] BB-17..BB-27 visible in Bloodbank Plane project with GOD-42 link
- [ ] HOLYF-2 visible in Holyfields Plane project