### PR TITLE
feat(hooks): repoint publisher at dedicated claude-events sidecar (GOD-43 V3-108)

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -10,11 +10,13 @@ Claude Code
     ↓ (PostToolUse / Stop / SessionStart)
 .claude/hooks/bloodbank-publisher.sh
     ↓ (POST /v1.0/publish/<pubsub>/<topic>, application/cloudevents+json)
-daprd-heartbeat sidecar (host:3502 → container:3500)
+daprd-claude-events sidecar (host:3503 → container:3500)
     ↓ (pubsub.jetstream component)
 NATS JetStream (BLOODBANK_V3_EVENTS stream, event.agent.* subjects)
-    ↓
-Subscribers (recorders, projections, dashboards)
+    ↓ Dapr delivers to claude-events-recorder app
+        → /events/{session_started,session_ended,tool_invoked}
+        → in-memory buffer + per-session aggregate
+        → GET /inspect/recorded (host:3602)
 ```
 
 The publisher is **best-effort by design**. If the Dapr sidecar is not
@@ -42,28 +44,30 @@ Set in `.claude/settings.json` under `env`:
 |------------------------------|-------------------------------|---------|
 | `BLOODBANK_ENABLED`          | `true`                        | `false` disables publishing entirely |
 | `BLOODBANK_DEBUG`            | `false`                       | `true` logs each publish to stderr |
-| `BLOODBANK_DAPR_URL`         | `http://localhost:3502`       | Dapr sidecar HTTP base URL |
+| `BLOODBANK_DAPR_URL`         | `http://localhost:3503`       | Dapr sidecar HTTP base URL |
 | `BLOODBANK_PUBSUB`           | `bloodbank-v3-pubsub`         | Dapr pubsub component name |
 | `BLOODBANK_PUBLISH_TIMEOUT`  | `2`                           | curl `--max-time` seconds |
 
 ## Bringing up the publish target
 
-The hook expects a daprd sidecar on `localhost:3502`. The simplest way
-to satisfy that today is the `heartbeat` profile, which runs the
-`daprd-heartbeat` sidecar that exposes its HTTP API on host port 3502:
+The hook expects a daprd sidecar on `localhost:3503`. Bring up the
+dedicated `claude-events` compose profile, which runs
+`daprd-claude-events` (sidecar exposed on host:3503) and
+`claude-events-recorder` (subscriber that records all three agent.*
+event types and exposes `/inspect/recorded` on host:3602):
 
 ```bash
 docker compose --project-name bloodbank-v3 \
-  --profile heartbeat \
+  --profile claude-events \
   -f bloodbank/compose/v3/docker-compose.yml \
-  up -d nats nats-init dapr-placement heartbeat-recorder daprd-heartbeat
+  up -d nats nats-init dapr-placement claude-events-recorder daprd-claude-events
 ```
 
-A dedicated `claude-events` compose profile (with its own daprd sidecar
-plus a `claude-events-recorder` for query/inspection) is a planned
-follow-up. Until then, daprd-heartbeat does double duty for
-publish-only workloads (Dapr publish is generic and not bound to the
-sidecar's app-id).
+You can run the heartbeat profile alongside this one (different ports,
+different sidecars) without conflict. If you only want to publish and
+don't care about the recorder, pointing `BLOODBANK_DAPR_URL` at any
+Dapr sidecar with the `bloodbank-v3-pubsub` component loaded will work
+(Dapr publish is generic and not bound to the sidecar's app-id).
 
 ## Verifying the round-trip
 
@@ -71,11 +75,10 @@ sidecar's app-id).
 # Hook fires session-start manually
 echo '{}' | .claude/hooks/bloodbank-publisher.sh session-start
 
-# Inspect what landed in the stream
-docker run --rm --network bloodbank-v3-network natsio/nats-box:0.14.5 \
-  nats --server nats://nats:4222 stream subjects BLOODBANK_V3_EVENTS
+# Inspect what the recorder captured
+curl -sS http://127.0.0.1:3602/inspect/recorded | jq '.count_by_type, .sessions'
 
-# Pull the actual envelope
+# Or pull the raw envelope from the stream
 docker run --rm -i --network bloodbank-v3-network natsio/nats-box:0.14.5 \
   nats --server nats://nats:4222 sub 'event.agent.session.started' \
   --count=1 --last-per-subject --raw

--- a/.claude/hooks/bloodbank-publisher.sh
+++ b/.claude/hooks/bloodbank-publisher.sh
@@ -23,9 +23,10 @@
 #   BLOODBANK_PUBSUB        Dapr pubsub component (default: bloodbank-v3-pubsub)
 #   BLOODBANK_PUBLISH_TIMEOUT  curl --max-time seconds (default: 2)
 #
-# Bring up the publish target (a daprd sidecar exposed on host:3502) via:
+# Bring up the publish target (a daprd sidecar exposed on host:3503) via:
 #   docker compose --project-name bloodbank-v3 \
-#     --profile heartbeat -f bloodbank/compose/v3/docker-compose.yml up -d
+#     --profile claude-events -f bloodbank/compose/v3/docker-compose.yml \
+#     up -d nats nats-init dapr-placement claude-events-recorder daprd-claude-events
 #
 # When the sidecar is down, errors are logged once to
 # .claude/sessions/publish-errors.log (rotated at ~1MB) and the hook
@@ -35,7 +36,7 @@ set -uo pipefail
 
 BLOODBANK_ENABLED="${BLOODBANK_ENABLED:-true}"
 BLOODBANK_DEBUG="${BLOODBANK_DEBUG:-false}"
-BLOODBANK_DAPR_URL="${BLOODBANK_DAPR_URL:-http://localhost:3502}"
+BLOODBANK_DAPR_URL="${BLOODBANK_DAPR_URL:-http://localhost:3503}"
 BLOODBANK_PUBSUB="${BLOODBANK_PUBSUB:-bloodbank-v3-pubsub}"
 BLOODBANK_PUBLISH_TIMEOUT="${BLOODBANK_PUBLISH_TIMEOUT:-2}"
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "env": {
     "BLOODBANK_ENABLED": "true",
     "BLOODBANK_DEBUG": "false",
-    "BLOODBANK_DAPR_URL": "http://localhost:3502",
+    "BLOODBANK_DAPR_URL": "http://localhost:3503",
     "BLOODBANK_PUBSUB": "bloodbank-v3-pubsub"
   },
   "hooks": {


### PR DESCRIPTION
## Summary

Companion to [bloodbank #31](https://github.com/delorenj/bloodbank/pull/31). The publisher hook now defaults to the dedicated `claude-events` daprd sidecar on **host:3503** instead of piggybacking on `daprd-heartbeat` (3502).

Closes V3-108 in the [GOD-43 epic](_bmad-output/planning-artifacts/epic-god-43-v3-stories.md).

### What changed

- `.claude/settings.json` — `BLOODBANK_DAPR_URL` default 3502 → 3503
- `.claude/hooks/bloodbank-publisher.sh` — same default, plus updated bring-up doc comment
- `.claude/hooks/README.md` — architecture diagram, env table, and round-trip-verify commands updated to use the new profile + recorder
- Bumps bloodbank submodule pointer `11a8424 → 87bf390`

### Why a separate sidecar

Both ports work today (Dapr publish is generic, not bound to sidecar app-id). 3503 is canonical going forward because:

- It's wired to `claude-events-recorder` which captures all three `agent.*` event types and exposes per-session aggregates at `http://localhost:3602/inspect/recorded`
- Separation of concerns: heartbeat profile drives the heartbeat feedback loop; claude-events profile drives Claude Code session observability
- Both profiles run side by side cleanly (different ports, different sidecars, different recorders)

### Verified

Live Claude Code session published through `host:3503` during verification:

```
recorder count: 20
count_by_type: {'agent.session.started': 2, 'agent.tool.invoked': 16, 'agent.session.ended': 2}
sessions: 3
```

The 16 tool.invoked events are real activity from this session (Read, Edit, Bash, etc.), confirming the integration is end-to-end live.

## Test plan

- [x] Manual hook fire (session-start, tool-action, session-end) reaches host:3503 with HTTP 204
- [x] Recorder captures all three event types with correct count_by_type
- [x] Per-session aggregate populates (started=true, ended=true, tool_invocations>0)
- [x] No regression with sidecar-down path: hook still exits 0, errors logged to .claude/sessions/publish-errors.log
- [x] bloodbank #31 CI green (smoke tests 1m41s, static 25s)